### PR TITLE
Füge Sensoren für Solarproduktion (heute & gestern) hinzu

### DIFF
--- a/custom_components/energie_impuls/__init__.py
+++ b/custom_components/energie_impuls/__init__.py
@@ -9,7 +9,7 @@ from .automation import AutomatikController
 from .api import EnergyImpulsSession
 from .const import DOMAIN, CONF_USERNAME, CONF_PASSWORD, CONF_WB_DEVICE_NAME, CONF_WB_DEVICE_ID, CONF_MODE_ENTITY, CONF_AUTO_SWITCH_ENTITY, CONF_AUTO_MIN_PV, DEFAULT_AUTO_MIN_PV, DEFAULT_AUTO_MINUTES, CONF_AUTO_MINUTES 
 
-from .coordinator import EnergieImpulsCoordinator, WallboxCoordinator
+from .coordinator import EnergieImpulsCoordinator, WallboxCoordinator, DailyProductionCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -28,6 +28,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     wallbox_coordinator = WallboxCoordinator(hass, session)
     await wallbox_coordinator.async_config_entry_first_refresh()
 
+    production_today_coordinator = DailyProductionCoordinator(
+        hass,
+        session,
+        name="energie_impuls_solarproduktion_heute",
+        update_interval=timedelta(minutes=15),
+        date_provider=lambda now: now.date(),
+    )
+    await production_today_coordinator.async_config_entry_first_refresh()
+
+    production_yesterday_coordinator = DailyProductionCoordinator(
+        hass,
+        session,
+        name="energie_impuls_solarproduktion_gestern",
+        update_interval=timedelta(hours=3),
+        date_provider=lambda now: (now - timedelta(days=1)).date(),
+    )
+    await production_yesterday_coordinator.async_config_entry_first_refresh()
+
 
     
     # 🔄 Asynchron Wallbox-Daten abrufen
@@ -44,6 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN]["coordinator_energie"] = energie_coordinator
     hass.data[DOMAIN]["coordinator_wallbox"] = wallbox_coordinator
+    hass.data[DOMAIN]["coordinator_production_today"] = production_today_coordinator
+    hass.data[DOMAIN]["coordinator_production_yesterday"] = production_yesterday_coordinator
     
     # Plattformen laden
     await hass.config_entries.async_forward_entry_setups(

--- a/custom_components/energie_impuls/api.py
+++ b/custom_components/energie_impuls/api.py
@@ -1,8 +1,9 @@
 import aiohttp
 import async_timeout
 import logging
+from datetime import date
 
-from .const import LOGIN_URL, DATA_URL, WALLBOX_URL, WALLBOX_SETPOINT_URL ,DOMAIN, CONF_WB_DEVICE_ID
+from .const import LOGIN_URL, DATA_URL, HOURLY_FLOW_URL, WALLBOX_URL, WALLBOX_SETPOINT_URL ,DOMAIN, CONF_WB_DEVICE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +56,11 @@ class EnergyImpulsSession:
     async def async_get_data(self):
         """Ruft Energiedaten ab (PV, Haushalt, etc.)."""
         return await self._authorized_get(DATA_URL)
+
+    async def async_get_hourlyflow_data(self, target_date: date):
+        """Ruft Tagesdaten inklusive Summen für ein Datum ab."""
+        url = f"{HOURLY_FLOW_URL}?date={target_date.isoformat()}&sync=true"
+        return await self._authorized_get(url)
 
     async def async_get_wallbox_data(self):
         """Ruft Wallboxdaten ab."""

--- a/custom_components/energie_impuls/const.py
+++ b/custom_components/energie_impuls/const.py
@@ -2,6 +2,7 @@
 DOMAIN = "energie_impuls"
 LOGIN_URL = "https://energie-impuls.site/api/auth/login"
 DATA_URL = "https://energie-impuls.site/api/c/devices/flow/"
+HOURLY_FLOW_URL = "https://energie-impuls.site/api/c/devices/hourlyflow/"
 WALLBOX_URL = "https://energie-impuls.site/api/c/devices/wallbox/?nested=true"
 WALLBOX_SETPOINT_URL = "https://energie-impuls.site/api/c/devices/wallbox/setpoint/"
 USER_ID = "user_id"

--- a/custom_components/energie_impuls/coordinator.py
+++ b/custom_components/energie_impuls/coordinator.py
@@ -1,5 +1,6 @@
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from datetime import timedelta
+from datetime import datetime
 from .const import PAYLOADS
 import logging
 
@@ -62,3 +63,23 @@ class WallboxCoordinator(DataUpdateCoordinator):
             except Exception as e:
                 _LOGGER.error(f"Fehler beim Setzen des Wallbox-Modus: {e}")
                 raise
+
+
+class DailyProductionCoordinator(DataUpdateCoordinator):
+    def __init__(self, hass, session, name, update_interval, date_provider):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=name,
+            update_interval=update_interval,
+        )
+        self.session = session
+        self._date_provider = date_provider
+
+    async def _async_update_data(self):
+        try:
+            target_date = self._date_provider(datetime.now().astimezone())
+            data = await self.session.async_get_hourlyflow_data(target_date)
+            return data.get("totals", {}).get("production")
+        except Exception as err:
+            raise UpdateFailed(f"Fehler beim Abrufen der Solarproduktion: {err}") from err

--- a/custom_components/energie_impuls/sensor.py
+++ b/custom_components/energie_impuls/sensor.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     energie_coordinator = hass.data[DOMAIN]["coordinator_energie"]
     wallbox_coordinator = hass.data[DOMAIN]["coordinator_wallbox"]
+    production_today_coordinator = hass.data[DOMAIN]["coordinator_production_today"]
+    production_yesterday_coordinator = hass.data[DOMAIN]["coordinator_production_yesterday"]
     sensors = [
         EnergieImpulsSensor(hass, energie_coordinator,"PV-Erzeugung", "pv", UnitOfPower.KILO_WATT,"mdi:solar-power-variant",SensorDeviceClass.POWER), 
         EnergieImpulsSensor(hass, energie_coordinator,"Netzeinspeisung", "to_grid", UnitOfPower.KILO_WATT,"mdi:transmission-tower",SensorDeviceClass.POWER), 
@@ -26,6 +28,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         WallboxSensor(hass, wallbox_coordinator, "Wallbox Modus", "wallbox_mode_str", lambda d: d["_state"]["mode_str"], None, "mdi:ev-plug-type2",SensorDeviceClass.ENUM),
         WallboxSensor(hass, wallbox_coordinator, "Wallbox Moduscode", "wallbox_mode", lambda d: d["_state"]["mode"]),
         WallboxSensor(hass, wallbox_coordinator, "Wallbox Verbrauch", "wallbox_consumption", lambda d: d["_state"]["consumption"], UnitOfPower.KILO_WATT, "mdi:ev-station",SensorDeviceClass.POWER),
+        DailyProductionSensor(hass, production_today_coordinator, "Solarproduktion heute", "production_today"),
+        DailyProductionSensor(hass, production_yesterday_coordinator, "Solarproduktion gestern", "production_yesterday"),
         #WallboxSensor(hass, wallbox_coordinator, "Wallbox Zeitstempel", "wallbox_timestamp", lambda d: d["_state"]["timestamp"]),
         #WallboxSensor(hass, wallbox_coordinator, "Wallbox Seit Modus aktiv", "wallbox_mode_since", lambda d: d["_state"]["mode_since"]),
         #WallboxSensor(hass, wallbox_coordinator, "Wallbox Standort-ID", "wallbox_location", lambda d: d["location"]),
@@ -113,3 +117,23 @@ class ShortWallboxModeSensor(WallboxSensor):
             value = value.replace("Fahrzeug", "").strip()
         self._state = value
         return "" if self._state is None else self._state
+
+
+class DailyProductionSensor(EnergieImpulsDeviceInfoMixin, CoordinatorEntity, SensorEntity):
+    def __init__(self, hass, coordinator, name, key):
+        super().__init__(coordinator)
+        self.hass = hass
+        self._attr_name = name
+        self._attr_unique_id = f"energie_impuls_{key}"
+        self._attr_native_unit_of_measurement = "kWh"
+        self._attr_icon = "mdi:solar-power"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_suggested_display_precision = 1
+
+    @property
+    def native_value(self):
+        value = self.coordinator.data
+        try:
+            return 0 if value is None else float(value)
+        except Exception:
+            return 0 if value is None else value


### PR DESCRIPTION
### Motivation
- Es werden separate Tageswerte für die PV‑Produktion benötigt und die API verlangt ein Datum in der URL, daher müssen heute und gestern separat abgefragt werden; der Wert kommt aus `totals.production`.
- Die Produktion von gestern ändert sich selten, daher soll dieser Sensor nur beim Start und danach im 3‑Stunden‑Rhythmus aktualisiert werden, während heute häufiger abgefragt wird.

### Description
- Ergänzt `HOURLY_FLOW_URL` und eine neue API‑Methode `EnergyImpulsSession.async_get_hourlyflow_data(target_date)` zum Abruf von `/hourlyflow/?date=YYYY-MM-DD&sync=true`.
- Implementiert `DailyProductionCoordinator` (wiederverwendbarer Coordinator mit `date_provider`), der `totals.production` aus der Tagesantwort extrahiert.
- Registriert zwei Coordinatoren in `async_setup_entry`: `production_today` (Update alle 15 Minuten) und `production_yesterday` (Update alle 3 Stunden, inkl. Initial‑Refresh beim Start), und legt sie in `hass.data` ab.
- Fügt zwei Sensor‑Entitäten hinzu (`Solarproduktion heute`, `Solarproduktion gestern`) mit Einheit `kWh` und `state_class`=TOTAL, die die Werte der jeweiligen Coordinatoren anzeigen.

### Testing
- Automatische Kompilierung ausgeführt mit `python -m compileall custom_components/energie_impuls`, die erfolgreich verlief.
- Die neuen Module wurden lokal kompiliert und die Änderungen statisch geprüft (keine fehlerhaften Imports/Parse‑Fehler festgestellt).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fa39d87c8329bd80dc536fda14ee)