### PR TITLE
Add battery charge/discharge sensors from today's totals

### DIFF
--- a/custom_components/energie_impuls/coordinator.py
+++ b/custom_components/energie_impuls/coordinator.py
@@ -80,6 +80,6 @@ class DailyProductionCoordinator(DataUpdateCoordinator):
         try:
             target_date = self._date_provider(datetime.now().astimezone())
             data = await self.session.async_get_hourlyflow_data(target_date)
-            return data.get("totals", {}).get("production")
+            return data.get("totals", {})
         except Exception as err:
             raise UpdateFailed(f"Fehler beim Abrufen der Solarproduktion: {err}") from err

--- a/custom_components/energie_impuls/sensor.py
+++ b/custom_components/energie_impuls/sensor.py
@@ -29,6 +29,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         WallboxSensor(hass, wallbox_coordinator, "Wallbox Moduscode", "wallbox_mode", lambda d: d["_state"]["mode"]),
         WallboxSensor(hass, wallbox_coordinator, "Wallbox Verbrauch", "wallbox_consumption", lambda d: d["_state"]["consumption"], UnitOfPower.KILO_WATT, "mdi:ev-station",SensorDeviceClass.POWER),
         DailyProductionSensor(hass, production_today_coordinator, "Solarproduktion heute", "production_today"),
+        DailyProductionSensor(hass, production_today_coordinator, "Batterie-Ladung heute", "battery_charge", "mdi:battery-plus"),
+        DailyProductionSensor(hass, production_today_coordinator, "Batterie-Entladung heute", "battery_discharge", "mdi:battery-minus"),
         DailyProductionSensor(hass, production_yesterday_coordinator, "Solarproduktion gestern", "production_yesterday"),
         #WallboxSensor(hass, wallbox_coordinator, "Wallbox Zeitstempel", "wallbox_timestamp", lambda d: d["_state"]["timestamp"]),
         #WallboxSensor(hass, wallbox_coordinator, "Wallbox Seit Modus aktiv", "wallbox_mode_since", lambda d: d["_state"]["mode_since"]),
@@ -120,19 +122,21 @@ class ShortWallboxModeSensor(WallboxSensor):
 
 
 class DailyProductionSensor(EnergieImpulsDeviceInfoMixin, CoordinatorEntity, SensorEntity):
-    def __init__(self, hass, coordinator, name, key):
+    def __init__(self, hass, coordinator, name, key, icon="mdi:solar-power"):
         super().__init__(coordinator)
         self.hass = hass
         self._attr_name = name
+        self._key = key
         self._attr_unique_id = f"energie_impuls_{key}"
         self._attr_native_unit_of_measurement = "kWh"
-        self._attr_icon = "mdi:solar-power"
+        self._attr_icon = icon
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_suggested_display_precision = 1
 
     @property
     def native_value(self):
-        value = self.coordinator.data
+        data = self.coordinator.data
+        value = data.get("production") if self._key in ("production_today", "production_yesterday") else data.get(self._key)
         try:
             return 0 if value is None else float(value)
         except Exception:


### PR DESCRIPTION
### Motivation
- Enable exposing battery charge/discharge daily totals from the hourly flow API so the integration can report today's battery charge and discharge values.
- Keep existing daily production sensors working while allowing additional keys from the API `totals` payload to be used by sensors.

### Description
- Update `DailyProductionCoordinator` to return the full `totals` object from `async_get_hourlyflow_data` instead of only the `production` value (`custom_components/energie_impuls/coordinator.py`).
- Add two new daily sensors for today: `Batterie-Ladung heute` (`battery_charge`) and `Batterie-Entladung heute` (`battery_discharge`) (`custom_components/energie_impuls/sensor.py`).
- Change `DailyProductionSensor` to accept an optional `icon` parameter and to read the appropriate key from the returned `totals` dict while preserving compatibility for `production_today`/`production_yesterday` keys (`custom_components/energie_impuls/sensor.py`).

### Testing
- Ran `python -m compileall custom_components/energie_impuls` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fed130bc8329a077d10cb398e594)