### PR TITLE
Fix Energy Dashboard warning for daily production sensor

### DIFF
--- a/custom_components/energie_impuls/sensor.py
+++ b/custom_components/energie_impuls/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     UnitOfPower,
+    UnitOfEnergy,
 )
 from .const import DOMAIN
 from .api import EnergyImpulsSession
@@ -125,8 +126,9 @@ class DailyProductionSensor(EnergieImpulsDeviceInfoMixin, CoordinatorEntity, Sen
         self.hass = hass
         self._attr_name = name
         self._attr_unique_id = f"energie_impuls_{key}"
-        self._attr_native_unit_of_measurement = "kWh"
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         self._attr_icon = "mdi:solar-power"
+        self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_suggested_display_precision = 1
 


### PR DESCRIPTION
### Motivation
- Ensure the daily solar production entities expose true energy semantics so Home Assistant Energy Dashboard recognizes them and no longer reports an "unexpected device class" warning.

### Description
- Import `UnitOfEnergy` and change the daily production sensors to use `UnitOfEnergy.KILO_WATT_HOUR` and set `device_class` to `SensorDeviceClass.ENERGY` in `custom_components/energie_impuls/sensor.py`.

### Testing
- Ran `git diff` to verify the changes, committed the file with `git commit`, and printed the updated file with `nl -ba` to confirm the new unit and device class were applied (all commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ff131a408329ac47dc3b2c329ca4)