### PR TITLE
Reduziere Aktualisierungsintervall des Tagessensors auf 5 Minuten

### DIFF
--- a/custom_components/energie_impuls/__init__.py
+++ b/custom_components/energie_impuls/__init__.py
@@ -32,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         session,
         name="energie_impuls_solarproduktion_heute",
-        update_interval=timedelta(minutes=15),
+        update_interval=timedelta(minutes=5),
         date_provider=lambda now: now.date(),
     )
     await production_today_coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
### Motivation
- Der Tagessensor für die aktuelle Solarproduktion soll häufiger aktualisiert werden, um zeitnähere Messwerte bereitzustellen.

### Description
- In `custom_components/energie_impuls/__init__.py` wurde das `production_today`-Coordinator `update_interval` von `timedelta(minutes=15)` auf `timedelta(minutes=5)` geändert.

### Testing
- `python -m compileall custom_components/energie_impuls/__init__.py` wurde erfolgreich ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0304611974832995ab8f7c7dcf7448)