### PR TITLE
docs: update README with new sensor entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Diese benutzerdefinierte Home Assistant-Integration verbindet dein Smart Home mi
   - PV-Erzeugung, Netzeinspeisung, Haushaltsverbrauch,...
   - Batterie-SOC (State of Charge)
   - Wallbox-Verbrauch & -Modus
+  - Tageswerte für Solarproduktion sowie Batterie-Ladung/-Entladung (heute & gestern)
 - **Wallbox-Steuerung, wie in der Energie-Impuls App**
 - **Logik-Elemente**:
   - Lademodus statt einzelne Wallbox-Schalter
@@ -101,20 +102,24 @@ Sobald irgendein Parameter von Hand umgestellt wird, so schaltet sich die Automa
 
 | Entity ID                              | Typ     | Beschreibung                                                                 |
 | :------------------------------------- | :------ | :--------------------------------------------------------------------------- |
-| sensor.pv                              | Sensor  | Aktuelle PV-Erzeugung in kW                                                 |
-| sensor.to_grid                         | Sensor  | Aktuelle Netzeinspeisung in kW                                              |
-| sensor.to_battery                      | Sensor  | Batterieladung in kW                                                        |
-| sensor.household                       | Sensor  | Haushaltsverbrauch in kW                                                    |
-| sensor.battery_soc                     | Sensor  | Batterieladestand in Prozent                                                |
-| sensor.wallbox_mode_str                | Sensor  | Aktueller Wallbox-Modus als lesbarer Text                                   |
-| sensor.wallbox_mode                    | Sensor  | Aktueller Wallbox-Moduscode (numerisch)                                     |
-| sensor.wallbox_consumption            | Sensor  | Stromverbrauch der Wallbox in kW                                            |
-| sensor.wallbox_mode_knx                | Sensor  | Gekürzter Wallbox-Modus für KNX-Anbindung (ohne „Fahrzeug“)                |
-| switch.energie_impuls_switch_locked    | Switch  | Sperrt oder entsperrt die Wallbox                                           |
-| switch.energie_impuls_switch_surplus_charging | Switch | Schaltet das Überschussladen der Wallbox ein/aus                         |
-| switch.energie_impuls_automatic_status | Switch  | Aktiviert oder deaktiviert die Automatiklogik                               |
-| select.energie_impuls_wallbox_mode     | Select  | Manuelle Auswahl des Lademodus (Schnellladen, Hybrid, etc.)                |
-| select.energie_impuls_automatic_mode   | Select  | Wahl des Automatikmodus (z. B. Hybrid-Automatik, Überschuss, etc.)         |
+| sensor.energie_impuls_pv               | Sensor  | Aktuelle PV-Erzeugung in kW                                                  |
+| sensor.energie_impuls_to_grid          | Sensor  | Aktuelle Netzeinspeisung in kW                                               |
+| sensor.energie_impuls_to_battery       | Sensor  | Batterieladung in kW                                                         |
+| sensor.energie_impuls_household        | Sensor  | Haushaltsverbrauch in kW                                                     |
+| sensor.energie_impuls_battery_soc      | Sensor  | Batterieladestand in Prozent                                                 |
+| sensor.energie_impuls_wallbox_mode_str | Sensor  | Aktueller Wallbox-Modus als lesbarer Text                                   |
+| sensor.energie_impuls_wallbox_mode     | Sensor  | Aktueller Wallbox-Moduscode (numerisch)                                     |
+| sensor.energie_impuls_wallbox_consumption | Sensor | Stromverbrauch der Wallbox in kW                                             |
+| sensor.energie_impuls_wallbox_mode_knx | Sensor  | Gekürzter Wallbox-Modus für KNX-Anbindung (ohne „Fahrzeug“)                 |
+| sensor.energie_impuls_production_today | Sensor  | Solarproduktion heute in kWh                                                 |
+| sensor.energie_impuls_battery_charge   | Sensor  | Batterie-Ladung heute in kWh                                                 |
+| sensor.energie_impuls_battery_discharge | Sensor | Batterie-Entladung heute in kWh                                              |
+| sensor.energie_impuls_production_yesterday | Sensor | Solarproduktion gestern in kWh                                            |
+| switch.energie_impuls_switch_locked    | Switch  | Sperrt oder entsperrt die Wallbox                                            |
+| switch.energie_impuls_switch_surplus_charging | Switch | Schaltet das Überschussladen der Wallbox ein/aus                          |
+| switch.energie_impuls_automatic_status | Switch  | Aktiviert oder deaktiviert die Automatiklogik                                |
+| select.energie_impuls_wallbox_mode     | Select  | Manuelle Auswahl des Lademodus (Schnellladen, Hybrid, etc.)                 |
+| select.energie_impuls_automatic_mode   | Select  | Wahl des Automatikmodus (z. B. Hybrid-Automatik, Überschuss, etc.)          |
 | number.energie_impuls_hybrid_current   | Number  | Einstellbarer Hybrid-Ladestrom in Ampere (0 = deaktiviert)                  |
 
 
@@ -158,4 +163,3 @@ Pull Requests, Bug Reports und Verbesserungsvorschläge sind willkommen.
 ## 📜 Lizenz
 
 MIT License – siehe [LICENSE](LICENSE)
-


### PR DESCRIPTION
### Motivation
- Die README sollte die neu hinzugefügten Tageswerte-Sensoren dokumentieren und die Entity-Namen auf die tatsächlichen `energie_impuls_*` IDs angleichen.

### Description
- Aktualisiert die Funktionsliste um Tageswerte (Solarproduktion sowie Batterie-Ladung/-Entladung für heute/gestern) und die Tabelle `Verfügbare Entitäten` auf die tatsächlichen `sensor.energie_impuls_*` Entity IDs sowie die neuen Sensoren `production_today`, `battery_charge`, `battery_discharge` und `production_yesterday`.

### Testing
- Dokumentations-Änderung wurde lokal gestaged und committet mit `git add README.md` und `git commit -m "docs: update README with new sensor entities"`, alle Befehle liefen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0304e5dbf08329b83e46d670f52471)